### PR TITLE
Add oversampling to temporal motion

### DIFF
--- a/examples/example_motion2.py
+++ b/examples/example_motion2.py
@@ -4,7 +4,7 @@ from torchvision.transforms import Compose
 import matplotlib.pyplot as plt
 import numpy as np
 
-from torchio.transforms.augmentation.intensity.random_motion2 import   MotionSimTransform
+from torchio.transforms.augmentation.intensity.random_motion2 import MotionSimTransform
 from copy import deepcopy
 from nibabel.viewers import OrthoSlicer3D as ov
 

--- a/examples/example_time_course_kspace_affines.py
+++ b/examples/example_time_course_kspace_affines.py
@@ -1,0 +1,31 @@
+from torchio.transforms.augmentation.intensity.random_motion_kspace_time_course import RandomMotionTimeCourseAffines
+from torchio import Image, ImagesDataset, transforms, INTENSITY, LABEL
+from torchvision.transforms import Compose
+import numpy as np
+from nibabel.viewers import OrthoSlicer3D as ov
+
+np.random.seed(12)
+
+out_dir = '/data/ghiles/'
+
+subject = [[
+    Image('T1', '/data/romain/HCPdata/suj_100307/T1w_1mm.nii.gz', INTENSITY),
+    Image('mask', '/data/romain/HCPdata/suj_100307/brain_mT1w_1mm.nii', LABEL)
+     ]]
+subjects_list = [subject]
+dataset = ImagesDataset(subject)
+sample = dataset[0]
+
+nT = 200
+time_points = [.5, 1.0]
+dim_modif = 4
+fitpars = np.zeros((6, nT))
+fitpars[dim_modif, :100] = 12
+
+ov(sample["T1"]["data"][0], sample["T1"]["affine"])
+
+transform = RandomMotionTimeCourseAffines(fitpars=fitpars, time_points=time_points, pct_oversampling=0.30, verbose=True)
+transformed = transform(sample)
+
+
+ov(transformed["T1"]["data"][0], sample["T1"]["affine"])

--- a/torchio/transforms/augmentation/intensity/random_motion_from_time_course.py
+++ b/torchio/transforms/augmentation/intensity/random_motion_from_time_course.py
@@ -291,37 +291,6 @@ class RandomMotionFromTimeCourse(RandomTransform):
         tiles = np.floor_divide(target_shape, data_shape, dtype=int)
         return np.tile(params_to_reshape, reps=tiles)
 
-    def _fft_im(self, image):
-        output = (np.fft.fftshift(np.fft.fftn(np.fft.ifftshift(image)))).astype(np.complex128)
-        return output
-
-    def _ifft_im(self, freq_domain):
-        output = np.fft.ifftshift(np.fft.ifftn(freq_domain))
-        return output
-
-    @staticmethod
-    def _oversample(data, perc_oversampling=.10):
-        """
-        Oversamples data with a zero padding. Adds perc_oversampling percentage values
-        """
-        data_shape = list(data.shape)
-        to_pad = np.ceil(np.asarray(data_shape) * perc_oversampling)
-        left_pad = np.floor(to_pad / 2).astype(int)
-        right_pad = np.ceil(to_pad / 2).astype(int)
-        # padding_values = np.stack((left_pad, right_pad), -1).reshape(-1)[::-1]
-        return np.pad(data, list(zip(left_pad, right_pad)))  # torch.nn.functional(data, tuple(padding_values))
-
-    @staticmethod
-    def crop_volume(data, cropping_shape):
-        '''
-        Cropping data to cropping_shape size. Cropping starts from center of the image
-        '''
-        vol_centers = (np.asarray(data.shape) / 2).astype(int)
-        dim_ranges = np.ceil(np.asarray(cropping_shape) / 2).astype(int)
-        slicing = [slice(dim_center - dim_range, dim_center + dim_range)
-                   for dim_center, dim_range in zip(vol_centers, dim_ranges)]
-        return data[slicing]
-
     def _translate_freq_domain(self, freq_domain):
         """
         image domain translation by adding phase shifts in frequency domain

--- a/torchio/transforms/augmentation/intensity/random_motion_from_time_course.py
+++ b/torchio/transforms/augmentation/intensity/random_motion_from_time_course.py
@@ -43,21 +43,28 @@ def create_rotation_matrix_3d(angles):
 class RandomMotionFromTimeCourse(RandomTransform):
 
     def __init__(self, nT=200, maxDisp=7, maxRot=3, noiseBasePars=6.5, swallowFrequency=2, swallowMagnitude=4.23554,
-                 suddenFrequency=4, suddenMagnitude=4.24424, displacement_shift=2,
-                 freq_encoding_dim=(0, 1, 2), preserve_center_pct=0.07, tr=2.3, es=4E-3, apply_mask=True, nufft=False,
-                 verbose=False, fitpars=None, read_func=lambda x: pd.read_csv(x).values):
+                 suddenFrequency=4, suddenMagnitude=4.24424, displacement_shift=False,
+                 freq_encoding_dim=(0, 1, 2), preserve_center_pct=0.07, tr=2.3, es=4E-3, nufft=False,
+                 verbose=False, fitpars=None, oversampling_pct=0.0, read_func=lambda x: pd.read_csv(x).values):
         """
-        :param image_name (str): key in data dictionary
-        :param std_rotation_angle (float) : std of rotations
-        :param std_translation (float) : std of translations
-        :param corrupt_pct (list of ints): range of percents
-        :param freq_encoding_dim (list of ints): randomly choose freq encoding dim
-        :param preserve_center_pct (float): percentage of k-space center to preserve
-        :param apply_mask (bool): apply mask to output or not
-        :param nufft (bool): whether to use nufft for introducing rotations
-        :param proc_scale (float or int) : -1 = piecewise, -2 = uncorrelated, 0 = retroMocoBox or float for random walk scale
-        :param num_pieces (int): number of pieces for piecewise constant simulation
-       raises ImportError if nufft is true but finufft cannot be imported
+        :param nT (int): number of points of the time course
+        :param maxDisp (float): maximal value of displacement in the perlin noise (useless if noiseBasePars is 0)
+        :param maxRot (float): maximal value of rotation in the perlin noise (useless if noiseBasePars is 0)
+        :param noiseBasePars (float): base value of the perlin noise to generate for the time course
+        :param swallowFrequency (int): number of swallowing movements to generate in the time course
+        :param swallowMagnitude (float): magnitude of the swallowing movements to generate
+        :param suddenFrequency (int): number of sudden movements to generate in the time course
+        :param suddenMagnitude (float): magnitude of the sudden movements to generate
+        :param displacement_shift (bool): whether or not to demean the time course by the values of the center of the kspace
+        :param freq_encoding_dim (tuple of ints): potential frequency encoding dims to use (one of them is randomly chosen)
+        :param preserve_center_pct (float between 0 and 1): percentage of the center of the kspace to preserve
+        :param tr (float): repetition time of the data acquisition (used for interpolating the time course movement)
+        :param es (float): echo spacing time of the data acquisition (used for interpolating the time course movement)
+        :param nufft (bool): whether or not to apply nufft (if false, no rotation is simulated)
+        :param fitpars : movement parameters to use (if specified, will be applied as such, no movement is simulated)
+        :param oversampling_pct (float): percentage with which the data will be oversampled in the image domain prior to applying the motion
+        :param read_func (function): if fitpars is a string, function to use to read the data. Must return an array of shape (6, nT)
+        :param verbose (bool): verbose
         """
 
         super(RandomMotionFromTimeCourse, self).__init__(verbose=verbose)
@@ -73,14 +80,14 @@ class RandomMotionFromTimeCourse(RandomTransform):
         self.suddenFrequency = np.random.randint(low=1, high=suddenFrequency) if suddenFrequency > 0 else 0
         self.suddenMagnitude = [np.random.uniform(high=suddenMagnitude/2),
                                 np.random.uniform(low=suddenMagnitude/2, high=suddenMagnitude)]
-        self.displacement_shift = np.random.uniform(high=displacement_shift)
+        self.displacement_shift = displacement_shift
         self.preserve_center_frequency_pct = preserve_center_pct
         self.freq_encoding_choice = freq_encoding_dim
-        self.apply_mask = apply_mask
         self.frequency_encoding_dim = np.random.choice(self.freq_encoding_choice)
         self.read_func = read_func
         self.fitpars = None if fitpars is None else self.read_fitpars(fitpars)
         self.nufft = nufft
+        self.oversampling_pct = oversampling_pct
         if (not finufft) and nufft:
             raise ImportError('finufftpy cannot be imported')
 
@@ -93,6 +100,10 @@ class RandomMotionFromTimeCourse(RandomTransform):
                 continue
             image_data = np.squeeze(image_dict['data'])[..., np.newaxis, np.newaxis]
             original_image = np.squeeze(image_data[:, :, :, 0, 0])
+            if self.oversampling_pct > 0.0:
+                original_image_shape = original_image.shape
+                original_image = self._oversample(original_image, self.oversampling_pct)
+
             self._calc_dimensions(original_image.shape)
 
             if self.fitpars is None:
@@ -117,6 +128,10 @@ class RandomMotionFromTimeCourse(RandomTransform):
 
             # magnitude
             corrupted_im = abs(corrupted_im)
+
+            if self.oversampling_pct > 0.0:
+                corrupted_im = self.crop_volume(corrupted_im, original_image_shape)
+
             image_dict["data"] = corrupted_im[np.newaxis, ...]
             image_dict['data'] = torch.from_numpy(image_dict['data'])
         return sample
@@ -245,17 +260,7 @@ class RandomMotionFromTimeCourse(RandomTransform):
         fitpars = self._interpolate_space_timing(fitpars)
         fitpars = self._tile_params_to_volume_dims(fitpars)
 
-        #rand_translations, rand_rotations = fitpars[:3].reshape([3] + self.im_shape), fitpars[3:].reshape([3] + self.im_shape)
-
-        #to_reshape[self.frequency_encoding_dim] = -1
-        #rand_translations, rand_rotations = fitpars[:3].reshape([3] + to_reshape), fitpars[3:].reshape([3] + to_reshape)
-
-        #ones_multiplicator = np.ones([3] + self.im_shape)
-        #rand_translations, rand_rotations = rand_translations * ones_multiplicator, rand_rotations * ones_multiplicator
-
-        #print(f' in _simul_motionfitpar shape rand_rotation {rand_rotations.shape}')
-
-        return fitpars #rand_translations, np.radians(rand_rotations)
+        return fitpars
 
     def _interpolate_space_timing(self, fitpars):
         n_phase, n_slice = self.phase_encoding_shape[0], self.phase_encoding_shape[1]
@@ -272,7 +277,6 @@ class RandomMotionFromTimeCourse(RandomTransform):
         # Equidistant time spacing
         teq = np.linspace(0, t_steps, self.nT)
         # Actual interpolation
-        #print("Shapes\nmg_total\t{}\nteq\t{}\nparams\t{}".format(mg_total.shape, teq.shape, fitpars.shape))
         fitpars_interp = np.asarray([np.interp(mg_total, teq, params) for params in fitpars])
         # Reshaping to phase encoding dimensions
         fitpars_interp = fitpars_interp.reshape([6] + self.phase_encoding_shape)
@@ -294,6 +298,29 @@ class RandomMotionFromTimeCourse(RandomTransform):
     def _ifft_im(self, freq_domain):
         output = np.fft.ifftshift(np.fft.ifftn(freq_domain))
         return output
+
+    @staticmethod
+    def _oversample(data, perc_oversampling=.10):
+        """
+        Oversamples data with a zero padding. Adds perc_oversampling percentage values
+        """
+        data_shape = list(data.shape)
+        to_pad = np.ceil(np.asarray(data_shape) * perc_oversampling)
+        left_pad = np.floor(to_pad / 2).astype(int)
+        right_pad = np.ceil(to_pad / 2).astype(int)
+        # padding_values = np.stack((left_pad, right_pad), -1).reshape(-1)[::-1]
+        return np.pad(data, list(zip(left_pad, right_pad)))  # torch.nn.functional(data, tuple(padding_values))
+
+    @staticmethod
+    def crop_volume(data, cropping_shape):
+        '''
+        Cropping data to cropping_shape size. Cropping starts from center of the image
+        '''
+        vol_centers = (np.asarray(data.shape) / 2).astype(int)
+        dim_ranges = np.ceil(np.asarray(cropping_shape) / 2).astype(int)
+        slicing = [slice(dim_center - dim_range, dim_center + dim_range)
+                   for dim_center, dim_range in zip(vol_centers, dim_ranges)]
+        return data[slicing]
 
     def _translate_freq_domain(self, freq_domain):
         """

--- a/torchio/transforms/augmentation/intensity/random_motion_kspace_time_course.py
+++ b/torchio/transforms/augmentation/intensity/random_motion_kspace_time_course.py
@@ -1,0 +1,100 @@
+import warnings
+import torch
+import numpy as np
+import nibabel as nb
+from nibabel.processing import resample_from_to
+from tqdm import tqdm
+import SimpleITK as sitk
+from scipy.linalg import logm, expm
+from ....utils import is_image_dict
+from ....torchio import INTENSITY, DATA, AFFINE
+from .. import Interpolation
+from .. import RandomTransform
+
+
+class RandomMotionTimeCourseAffines(RandomTransform):
+
+    def __init__(self, fitpars, time_points=[0.0, 0.25, 0.5, 0.75], pct_oversampling=0.0, combine_axis=2,
+                 seed=None, verbose=False):
+        super().__init__(seed=seed, verbose=verbose)
+        self.fitpars = fitpars
+        self.time_points = time_points
+        self.pct_oversampling = pct_oversampling
+        self.affines = self.extract_affines_from_timecourse()
+        self.combine_axis = combine_axis
+
+    def combine_kspaces(self, spectra, axis=2):
+        """
+        Combines the k_spaces in spectra according to times values, if not specified, uniform times are assumed
+        """
+        nb_spectrums = len(spectra)
+        spects = spectra
+        kspace_shape = spects[0].shape
+
+        result_spectrum = np.empty_like(spects[0])
+        times = np.linspace(0, 1, nb_spectrums + 1, endpoint=True)[1:] if self.time_points is None else np.asarray(self.time_points)
+        indices = (kspace_shape[axis] * times).astype(int) + 1
+        start_idx = 0
+        slicing = [slice(None)] * 3
+        for spectrum, fin in zip(spects, indices):
+            slicing[axis] = slice(start_idx, fin)
+            result_spectrum[slicing] = spectrum[slicing]
+            start_idx = fin
+        result_image = abs(self._ifft_im(result_spectrum))
+        return result_image.astype(np.float32)
+
+    @staticmethod
+    def fitpars_to_matrix(fitpars):
+        '''
+        Converts fitpars (6 params : 3 translations and 3 rotations) to the corresponding affine transform matrix (4x4)
+        '''
+        transform = sitk.Euler3DTransform()
+        transform.SetTranslation(fitpars[:3])
+        transform.SetRotation(*np.radians(fitpars[3:]))
+        matrix = np.empty((4, 4))
+        rotation = np.array(transform.GetMatrix()).reshape(3, 3)
+        matrix[:3, :3] = rotation
+        matrix[:3, 3] = transform.GetTranslation()
+        return matrix
+
+    def extract_affines_from_timecourse(self):
+        '''
+        Extract the affines found at the specified timepoints in the fitpars timecourse
+        '''
+        fpars_len = self.fitpars.shape[1]
+        affines = []
+        for time in self.time_points:
+            extraction_index = int(fpars_len*time) - 1
+            fpars = self.fitpars[:, extraction_index]
+            affines.append(self.fitpars_to_matrix(fpars))
+        return affines
+
+    def apply_affines(self, data, affines, orig_affine=np.eye(4)):
+        trsfms_affine = [orig_affine.dot(trsfm_affine) for trsfm_affine in affines]
+        nb_data = data
+        if isinstance(nb_data, np.ndarray):
+            nb_data = nb.Nifti1Image(nb_data, orig_affine)
+        resampled_data = [resample_from_to(nb_data, (data.shape, trsfm_affine)) for trsfm_affine in trsfms_affine]
+        return resampled_data
+
+    def apply_transform(self, sample):
+        for image_name, image_dict in sample.items():
+            if not is_image_dict(image_dict):
+                continue
+            if image_dict['type'] != INTENSITY:
+                continue
+
+            data = np.squeeze(image_dict["data"])
+            original_shape = data.shape
+            oversampled_data = self._oversample(data, self.pct_oversampling)
+            transformed_data = self.apply_affines(oversampled_data, self.affines, orig_affine=np.eye(4))
+            transformed_kspace_data = [self._fft_im(corrupted_data.get_fdata()) for corrupted_data in transformed_data]
+            artifacted_data = self.combine_kspaces(transformed_kspace_data, axis=self.combine_axis)
+            cropped_artifacted_data = self.crop_volume(artifacted_data, original_shape)
+
+            image_dict["data"] = torch.from_numpy(cropped_artifacted_data[np.newaxis, ...])
+        return sample
+
+    @staticmethod
+    def get_params(*args, **kwargs):
+        pass

--- a/torchio/transforms/transform.py
+++ b/torchio/transforms/transform.py
@@ -50,3 +50,38 @@ class Transform(ABC):
     @staticmethod
     def sitk_to_nib(image):
         return sitk_to_nib(image)
+
+    @staticmethod
+    def _fft_im(image):
+        output = (np.fft.fftshift(np.fft.fftn(np.fft.ifftshift(image)))).astype(np.complex128)
+        return output
+
+    @staticmethod
+    def _ifft_im(freq_domain):
+        output = np.fft.ifftshift(np.fft.ifftn(freq_domain))
+        return output
+
+    @staticmethod
+    def _oversample(data, perc_oversampling=.10):
+        """
+        Oversamples data with a zero padding. Adds perc_oversampling percentage values
+        :param data (ndarray): array to pad
+        :param perc_oversampling (float): percentage of oversampling to add to data (based on its current shape)
+        :return oversampled version of the data:
+        """
+        data_shape = list(data.shape)
+        to_pad = np.ceil(np.asarray(data_shape) * perc_oversampling)
+        left_pad = np.floor(to_pad / 2).astype(int)
+        right_pad = np.ceil(to_pad / 2).astype(int)
+        return np.pad(data, list(zip(left_pad, right_pad)))
+
+    @staticmethod
+    def crop_volume(data, cropping_shape):
+        '''
+        Cropping data to cropping_shape size. Cropping starts from center of the image
+        '''
+        vol_centers = (np.asarray(data.shape) / 2).astype(int)
+        dim_ranges = np.ceil(np.asarray(cropping_shape) / 2).astype(int)
+        slicing = [slice(dim_center - dim_range, dim_center + dim_range)
+                   for dim_center, dim_range in zip(vol_centers, dim_ranges)]
+        return data[slicing]


### PR DESCRIPTION
I added an option to oversample the volume prior to adding the artifact and a crop before returning the artifacted data in the Time Course version of the motion artifact simulation.