### PR TITLE
Resample with coregistration matrix

### DIFF
--- a/tests/transforms/preprocessing/test_resample.py
+++ b/tests/transforms/preprocessing/test_resample.py
@@ -1,3 +1,4 @@
+import numpy as np
 from numpy.testing import assert_array_equal
 from torchio import DATA, AFFINE
 from torchio.transforms import Resample
@@ -26,6 +27,19 @@ class TestResample(TorchioTestCase):
             self.assertEqual(
                 ref_image_dict[DATA].shape, image_dict[DATA].shape)
             assert_array_equal(ref_image_dict[AFFINE], image_dict[AFFINE])
+
+    def test_coregistration(self):
+        spacing = 1
+        coregistration_name = 'coregistration'
+        transform = Resample(spacing, coregistration=coregistration_name)
+        transformed = transform(self.sample)
+        for image_dict in transformed.values():
+            if coregistration_name in image_dict.keys():
+                new_affine = np.eye(4)
+                new_affine[0, 3] = 10
+                assert_array_equal(image_dict[AFFINE], new_affine)
+            else:
+                assert_array_equal(image_dict[AFFINE], np.eye(4))
 
     def test_wrong_spacing_length(self):
         with self.assertRaises(ValueError):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import random
 import tempfile
@@ -13,7 +14,7 @@ class TorchioTestCase(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures, if any."""
-        self.dir = Path(tempfile.gettempdir()) / '.torchio_tests'
+        self.dir = Path(os.path.join(tempfile.gettempdir(), os.urandom(24).hex()))
         self.dir.mkdir(exist_ok=True)
         random.seed(42)
         np.random.seed(42)
@@ -67,7 +68,7 @@ class TorchioTestCase(unittest.TestCase):
         shutil.rmtree(self.dir)
 
     def get_ixi_tiny(self):
-        root_dir = Path(tempfile.gettempdir()) / 'torchio' / 'ixi_tiny'
+        root_dir = self.dir / 'ixi_tiny'
         return IXITiny(root_dir, download=True)
 
     def get_image_path(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,6 +19,13 @@ class TorchioTestCase(unittest.TestCase):
         random.seed(42)
         np.random.seed(42)
 
+        coregistration_matrix = np.array([
+            [1, 0, 0, 10],
+            [0, 1, 0, 0],
+            [0, 0, 1.2, 0],
+            [0, 0, 0, 1]
+        ])
+
         subject_a = Subject(
             t1=Image(self.get_image_path('t1_a'), INTENSITY),
         )
@@ -30,7 +37,7 @@ class TorchioTestCase(unittest.TestCase):
             label=Image(self.get_image_path('label_c', binary=True), LABEL),
         )
         subject_d = Subject(
-            t1=Image(self.get_image_path('t1_d'), INTENSITY),
+            t1=Image(self.get_image_path('t1_d'), INTENSITY, coregistration=coregistration_matrix),
             t2=Image(self.get_image_path('t2_d'), INTENSITY),
             label=Image(self.get_image_path('label_d', binary=True), LABEL),
         )


### PR DESCRIPTION
Add option in Resample transform to take into account a coregistration matrix.

Usage:
```python
import numpy as np
import torchio
from torchio.transforms import Resample
from torchvision.transforms import Compose

coregistration = np.eye(4)
subject = torchio.Subject(
    t1=torchio.Image(img_path, torchio.INTENSITY, coregistration=coregistration),
    label=torchio.Image(mask_path, torchio.LABEL),
    ref=torchio.Image(ref_path, torchio.INTENSITY),
)
subject_list = [subject]
transforms = [
    Resample(target='ref', coregistration='coregistration'),
]
transform = Compose(transforms)
dataset = torchio.ImagesDataset(subject_list, transform=transform)
```