### PR TITLE
refactor RandomMotionFromTimeCourse

### DIFF
--- a/torchio/transforms/augmentation/intensity/random_motion_from_time_course.py
+++ b/torchio/transforms/augmentation/intensity/random_motion_from_time_course.py
@@ -303,10 +303,6 @@ class RandomMotionFromTimeCourse(RandomTransform):
 
             fitpars += suddenTrace
 
-        if self.displacement_shift_strategy == "center_zero":
-            to_substract = fitpars[:, int(round(self.nT / 2))]
-            fitpars = np.subtract(fitpars, to_substract[..., np.newaxis])
-
         if self.preserve_center_frequency_pct:
             center = np.int(np.floor(fitpars.shape[1]/2))
             nbpts = np.int(np.floor(fitpars.shape[1] * self.preserve_center_frequency_pct/2))


### PR DESCRIPTION
Salut,

une PR pour alléger un peu le code de la transform RandomMotionFromTimeCourse:

- uniformisation des arguments aux transformations TorchIO (notamment modification de proba_to_augment renommée en p, il faudra donc changer ça sur le csv)

- tous les appels à np.random ont été remplacés par des version PyTorch (réimplémentées directement dans la classe)

- conversion de displacement_shift en booléen 

- stockage de certaines métriques en tant qu'attribut de classe et suppression d'autres attributs volumineux (volumes de rotations et translations)

Il y a des bouts de code que j'ai laissés en commentaire, comme je ne savais s'il fallait les supprimer ou si ça pourrait re-servir, il faudra que tu me dises @romainVala 